### PR TITLE
[codex] Resolve Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ fonttools==4.62.1
     # via matplotlib
 greenlet==3.4.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
     # via sqlalchemy
-idna==3.13
+idna==3.16
     # via requests
 imagesize==2.0.0
     # via sphinx


### PR DESCRIPTION
## Summary
- Update the transitive `idna` pin from 3.13 to 3.16 in `requirements.txt`.
- Resolves the current open Dependabot alert GHSA-65pc-fj4g-8rjx for `idna < 3.15`.

## Root cause
After PR #35 and PR #36 were merged, the only remaining open Dependabot alert on the default branch was the `idna` advisory. The lockfile still pinned `idna==3.13`, below the patched version.

## Validation
- `uv pip compile requirements.in --universal --python-version 3.11 -o requirements.txt`
- `git diff --exit-code requirements.txt`
- `git diff --check HEAD`