### PR TITLE
Raise vulnerable dependency floors

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,8 @@ pytest
 nbconvert
 nbformat
 pyyaml
+
+# Security floors for transitive dependencies flagged by Dependabot.
+bleach>=6.4.0
+jupyter-server>=2.20.0
+tornado>=6.5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,10 @@ attrs==26.1.0
     #   referencing
 beautifulsoup4==4.14.3
     # via nbconvert
-bleach==6.3.0
-    # via nbconvert
+bleach==6.4.0
+    # via
+    #   -r requirements.in
+    #   nbconvert
 cffi==2.0.0
     # via
     #   argon2-cffi-bindings
@@ -96,8 +98,10 @@ jupyter-core==5.9.1
     #   nbformat
 jupyter-events==0.12.1
     # via jupyter-server
-jupyter-server==2.18.2
-    # via jupyter-book
+jupyter-server==2.20.0
+    # via
+    #   -r requirements.in
+    #   jupyter-book
 jupyter-server-terminals==0.5.4
     # via jupyter-server
 jupyterlab-pygments==0.3.0
@@ -256,8 +260,9 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via bleach
-tornado==6.5.5
+tornado==6.5.7
     # via
+    #   -r requirements.in
     #   ipykernel
     #   jupyter-client
     #   jupyter-server


### PR DESCRIPTION
## Summary

Adds explicit security floors for vulnerable transitive dependencies reported by Dependabot:

- `bleach>=6.4.0`
- `jupyter-server>=2.20.0`
- `tornado>=6.5.7`

Regenerates `requirements.txt` with `uv` so the frozen environment resolves to the patched versions.

## Dependabot Alerts

Targets the open `requirements.txt` alerts for `jupyter-server`, `bleach`, and `tornado` on the default branch.

## Validation

- `uv --cache-dir /tmp/uv-cache pip compile requirements.in --universal --python-version 3.11 -o requirements.txt --custom-compile-command "uv pip compile requirements.in --universal --python-version 3.11 -o requirements.txt"`
- `python -m pytest tests/test_structure.py tests/test_notebooks.py -m 'not slow'` passed: 13 passed, 1 deselected
- `uv --cache-dir /tmp/uv-cache run --with-requirements requirements.txt python -c "import bleach, jupyter_server, tornado; ..."` verified `bleach 6.4.0`, `jupyter-server 2.20.0`, and `tornado 6.5.7`
- `uv --cache-dir /tmp/uv-cache run --with-requirements requirements.txt pytest -m 'not slow'` passed 15 tests; 2 build tests failed before the book build because the local MyST CLI reports `npm` as `Package Not Found`. The host has `/usr/bin/npm` 9.2.0, and CI uses `actions/setup-node@v4` with Node 20.
