### PR TITLE
Harden repository maintenance workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   # Also allow manual triggering
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds explicit read-only `GITHUB_TOKEN` permissions to the PR test workflow.
- Adds Dependabot configuration for weekly `pip` and GitHub Actions update PRs.

## Why

CodeQL reports three `actions/missing-workflow-permissions` alerts for `.github/workflows/test.yml`. Setting `contents: read` at the workflow level gives the jobs the minimum token scope they need for checkout and removes the implicit default token permissions.

The repository did not have `.github/dependabot.yml`, so routine dependency update PRs were not configured even though dependency alerts are enabled.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml')); yaml.safe_load(open('.github/dependabot.yml'))"`
- `python -m pytest tests/test_structure.py -v` passed: 8 passed
